### PR TITLE
update docs with default export AddOnScriptSdk

### DIFF
--- a/src/pages/references/scriptruntime/communication/index.md
+++ b/src/pages/references/scriptruntime/communication/index.md
@@ -8,12 +8,12 @@ The script runtime and iframe runtime are two different runtime execution enviro
 
 ## Accessing the APIs
 
-An exported module named `AddOnSdkApi` is provided to enable the communication between the iframe and the script runtime via its' `instance.runtime` object. You can simply import it into your script file code for use and create a reference to the `runtime` object. For example:
+A default export to the module `AddOnScriptSdk` is provided to enable the communication between the iframe and the script runtime via its' `instance.runtime` object. You can simply import it into your script file code for use and create a reference to the `runtime` object. For example:
 
 ```js
-import { AddOnSdkApi } from "AddOnSdkApi"; // named import is AddOnSdkApi
+import AddOnScriptSdk from "AddOnScriptSdk"; // AddOnScriptSdk is default import
 
-const { runtime } = AddOnSdkApi.instance; // runtime object provides direct access to the comm methods
+const { runtime } = AddOnScriptSdk.instance; // runtime object provides direct access to the comm methods
 ```
 
 ## Examples
@@ -27,8 +27,8 @@ This example shows how to expose APIs from the script runtime (via `code.js`) fo
 #### `code.js`
 
 ```js
-import { AddOnSdkApi } from "AddOnSdkApi";
-const { runtime } = AddOnSdkApi.instance;
+import AddOnScriptSdk from "AddOnScriptSdk";
+const { runtime } = AddOnScriptSdk.instance;
 
 const scriptApis = {
     performWorkOnDocument: function (data, someFlag) {
@@ -99,8 +99,8 @@ AddOnSdk.ready.then(async () => {
 #### `code.js`
 
 ```js
-import { AddOnSdkApi } from "AddOnSdkApi";
-const { runtime } = AddOnSdkApi.instance;
+import AddOnScriptSdk from "AddOnScriptSdk";
+const { runtime } = AddOnScriptSdk.instance;
 
 async function callUIApis() {
     // Get a proxy to the APIs defined in the UI


### PR DESCRIPTION
In iframe sdk currently we have default export,
However, in script sdk we have named export

In code.js (currently)
`import { AddOnSdkApi } from "AddOnSdkApi";`
To keep the imports consistent in both runtimes, we have decided to have default export from script sdk as well.
In code.js (after the change)
`import AddOnScriptSdk from "AddOnScriptSdk";`


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
