### PR TITLE
Add npx CLI troubleshooting info

### DIFF
--- a/src/pages/guides/getting_started/quickstart.md
+++ b/src/pages/guides/getting_started/quickstart.md
@@ -57,9 +57,24 @@ This command will create a new add-on based on a basic `javascript` template. Se
 
    **For Windows Users:** If you're using the CLI in the terminal, you'll need to add `openssl` to the `path` under Environment Variables. If `git` is installed, `openssl` can be found at `C:\Program >Files\Git\usr\bin`. Otherwise, you can download `git` from https://git-scm.com/downloads, and add the directory location to the `path` variable in your Environment Variables.
 
-<InlineAlert slots="text" variant="success"/>
+<InlineAlert slots="heading, text1, text2, text3, text4, text5" variant="info"/>
+
+#### CLI troubleshooting <!-- 👈 will not render -->
 
 `npx` is an `npm` package runner that can execute packages without installing them explicitly.
+
+Please run this command to clear the `npx` cache and ensure the latest version of the CLI is invoked.
+
+```bash
+npx clear-npx-cache
+npx @adobe/create-ccweb-add-on hello-world 
+```
+
+The above may prove useful when updated version of the CLI are released. If you want to read each individual CLI command manual pages, run them via `npx` with the `--help` flag, for example:
+
+```bash
+npx @adobe/ccweb-add-on-scripts start --help  
+```
 
 ## Step 2: Build and start your add-on
 


### PR DESCRIPTION
## Description

Minimal edit to integrate the existing box about `npx` in the Quickstart with useful information—particularly around `npx` caching, which may force using the old CLI even if a new version has been released.

## Screenshots

From this:

<img width="941" alt="image" src="https://github.com/AdobeDocs/express-add-ons-docs/assets/5939127/fe123d68-0b9a-4c59-a272-011da110a6ba">

To this:

<img width="1017" alt="image" src="https://github.com/AdobeDocs/express-add-ons-docs/assets/5939127/d729b656-fb2f-47ab-ac01-a765149ea169">

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
