### PR TITLE
Fix old "express" import

### DIFF
--- a/src/pages/guides/tutorials/stats-addon.md
+++ b/src/pages/guides/tutorials/stats-addon.md
@@ -1031,7 +1031,7 @@ export { rebuildTable };
 import addOnSandboxSdk from "add-on-sdk-document-sandbox";
 const { runtime } = addOnSandboxSdk.instance;
 
-import { editor } from "express";
+import { editor } from "express-document-sdk";
 import { getNodeData } from "./utils";
 
 async function start() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There was one last import with the old name left... hidden in plain sight!

```js
❌ import { editor } from "express";
✅  import { editor } from "express-document-sdk";
```


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
