### PR TITLE
Premium content API + Grids video

### DIFF
--- a/src/pages/guides/develop/use_cases.md
+++ b/src/pages/guides/develop/use_cases.md
@@ -122,6 +122,9 @@ const showPremiumContentError = async () => {
   });
   if (buttonType === ButtonType.cancel) return;
   if (buttonType === ButtonType.secondary) {
+    // Deprecated method
+    // ❌ window.open("https://www.adobe.com/go/express_addons_pricing", "_blank")
+    // 👇 Use startPremiumUpgradeIfFreeUser() instead 
     const hasUpgradedToPremiumUser = await app.startPremiumUpgradeIfFreeUser();
     if (!hasUpgradedToPremiumUser) {
       // User did not upgrade, show error dialog
@@ -134,7 +137,7 @@ const showPremiumContentError = async () => {
 }
 
 document.querySelector("#export").onclick = async () => {
-  // 👇 Testing purposes only! 👇 
+  // 👇 Testing purposes only!
   app.devFlags.simulateFreeUser = true; // Remove this line in production!
   
   const userIsPremium = await app.currentUser.isPremiumUser();

--- a/src/pages/guides/develop/use_cases.md
+++ b/src/pages/guides/develop/use_cases.md
@@ -741,10 +741,6 @@ addOnUISdk.app.on("documentTitleChange", data => {
 
 If you want to retrieve metadata for pages in the document, use the [`getPagesMetadata()`](../../references/addonsdk/app-document.md#getpagesmetadata) method in the `addOnUISdk.app.document` object as shown in the example below.
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This method is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use this method, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../references/manifest/index.md#requirements) section of the `manifest.json`.
-
 <CodeBlock slots="heading, code" repeat="1" languages="JavaScript" />
 
 #### Usage

--- a/src/pages/guides/tutorials/grids-addon.md
+++ b/src/pages/guides/tutorials/grids-addon.md
@@ -25,6 +25,10 @@ This tutorial will guide you through the creation of your first Adobe Express ad
 
 Hello, and welcome to this Adobe Express Document API tutorial, where we'll build together a **fully functional Grid System add-on** from scratch. Grid systems are widely used in the design world to bring structure and consistency to all visual content, from flyers to web pages or social media posts.
 
+<div style="display: flex; justify-content: center; margin-top: 20px;">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/SQMYA660gII?si=KOWp7FVBG4Ms3C3o" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div><br/>
+
 ![](images/grids-addon.png)
 
 Your add-on will allow users to create a variable number of rows and columns, control the spacing between them (known as the _gutter_), and apply color overlays.

--- a/src/pages/guides/tutorials/grids-addon.md
+++ b/src/pages/guides/tutorials/grids-addon.md
@@ -25,9 +25,9 @@ This tutorial will guide you through the creation of your first Adobe Express ad
 
 Hello, and welcome to this Adobe Express Document API tutorial, where we'll build together a **fully functional Grid System add-on** from scratch. Grid systems are widely used in the design world to bring structure and consistency to all visual content, from flyers to web pages or social media posts.
 
-<div style="display: flex; justify-content: center; margin-top: 20px;">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/SQMYA660gII?si=KOWp7FVBG4Ms3C3o" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</div><br/>
+<Media slots="video"/>
+
+<https://www.youtube.com/watch?v=SQMYA660gII>
 
 ![](images/grids-addon.png)
 

--- a/src/pages/references/addonsdk/addonsdk-app.md
+++ b/src/pages/references/addonsdk/addonsdk-app.md
@@ -110,10 +110,6 @@ addOnUISdk.app.off("themechange", (data) => {
 
 Displays the in-app monetization upgrade flow.
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This method is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use this method, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../manifest/index.md#requirements) section of the `manifest.json`.
-
 #### Signature
 
 `startPremiumUpgradeIfFreeUser(): Promise<boolean>`

--- a/src/pages/references/addonsdk/addonsdk-app.md
+++ b/src/pages/references/addonsdk/addonsdk-app.md
@@ -5,7 +5,7 @@ Provides access to the Adobe Express host application's objects and methods to p
 ## Objects
 
 <table class="spectrum-Table spectrum-Table--sizeM" css="
-    background-color:lavender; 
+    background-color:lavender;
     tbody {
       background-color:white;
     }">
@@ -353,7 +353,7 @@ See the [Drag & Drop use case implementation](../../guides/develop/use_cases.md#
 The table below describes the events triggered from the add-on SDK. Use the `addOnUISdk.app.on()` method to subscribe to events, and the `addOnUISdk.app.off()` method to unsubscribe from them. See the [`on()`](#on) method reference for more details.
 
 <table class="spectrum-Table spectrum-Table--sizeM" css="
-    background-color:lavender; 
+    background-color:lavender;
     tbody {
       background-color:white;
     }">

--- a/src/pages/references/addonsdk/addonsdk-constants.md
+++ b/src/pages/references/addonsdk/addonsdk-constants.md
@@ -5,7 +5,7 @@ A set of constants used throughout the add-on SDK. These constants are equal to 
 ## Constants
 
 <table columnWidths="30,20,60" class="spectrum-Table spectrum-Table--sizeM" css="
-    background-color:lavender; 
+    background-color:lavender;
     tbody {
       background-color:white;
     }">

--- a/src/pages/references/addonsdk/addonsdk-instance.md
+++ b/src/pages/references/addonsdk/addonsdk-instance.md
@@ -5,7 +5,7 @@ Represents the currently running add-on instance. This object is used for provid
 ## Objects
 
 <table columnWidths="20,50,30" class="spectrum-Table spectrum-Table--sizeM" css="
-    background-color:lavender; 
+    background-color:lavender;
     tbody {
       background-color:white;
     }">

--- a/src/pages/references/addonsdk/addonsdk.md
+++ b/src/pages/references/addonsdk/addonsdk.md
@@ -5,7 +5,7 @@ The core add-on UI SDK object which provides access to everything needed for add
 ## addOnUISdk Properties
 
 <table class="spectrum-Table spectrum-Table--sizeM" css="
-    background-color:lavender; 
+    background-color:lavender;
     tbody {
       background-color:white;
     }">

--- a/src/pages/references/addonsdk/app-currentUser.md
+++ b/src/pages/references/addonsdk/app-currentUser.md
@@ -39,10 +39,6 @@ addOnUISdk.ready.then(async () => {
 
 Indicates if the current user is a premium user.
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This method is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use this method, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../manifest/index.md#requirements) section of the `manifest.json`.
-
 #### Signature
 
 `isPremiumUser(): Promise<boolean>`

--- a/src/pages/references/addonsdk/app-devFlags.md
+++ b/src/pages/references/addonsdk/app-devFlags.md
@@ -30,4 +30,4 @@ addOnUISdk.ready.then(async () => {
 });
 ```
 
-See this [export content use case example](../../guides/develop/use_cases.md#option-1-show-premium-content-error-with-upgrade-option) which uses this flag for more details.
+See this [export content use case example](../../guides/develop/use_cases.md#option-1-show-a-premium-content-error-with-the-upgrade-option) which uses this flag for more details.

--- a/src/pages/references/addonsdk/index.md
+++ b/src/pages/references/addonsdk/index.md
@@ -102,7 +102,7 @@ See the [typescript definitions section](../../guides/develop/frameworks-librari
 The following properties can be accessed from the `addOnUISdk` object after it has been imported.<br/><br/>
 
 <table columnWidths="20,30,15,35" class="spectrum-Table spectrum-Table--sizeM" css="
-    background-color:lavender; 
+    background-color:lavender;
     tbody {
       background-color:white;
     }">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Update the Premium content use case

- `isPremiumUser`, `startPremiumUpgradeIfFreeUser`, and `getPagesMetadata` APIs move from experimental to stable.
- Add simplified `startPremiumUpgradeIfFreeUser()` workflow
- Add a case with pre-export check for premium content
- Make linter happy
- Unrelated: add video to Grids tutorial

## Related Issue

See [this Slack post](https://photoshop.slack.com/archives/C03PFLPK1LM/p1708699830939549) from Kerri

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
