### PR TITLE
AddOnSdk updates

### DIFF
--- a/src/pages/references/addonsdk/addonsdk-app.md
+++ b/src/pages/references/addonsdk/addonsdk-app.md
@@ -255,6 +255,10 @@ See the use case implementations for an example of the [custom modal dialog](../
 
 Allows an iframe hosted within an add-on to register its intent to communicate with the add-on SDK. While iframes can be used for embedding media without SDK interaction, `registerIframe()` is needed for those requiring SDK capabilities. It marks a transition to a more controlled approach, where add-ons must explicitly opt-in to this level of integration.
 
+<InlineAlert slots="text" variant="warning"/>
+
+**IMPORTANT:** This method is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use this method, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../manifest/index.md#requirements) section of the `manifest.json`.
+
 #### Signature
 
 `registerIframe(element: HTMLIFrameElement): [UnregisterIframe]()`

--- a/src/pages/references/addonsdk/addonsdk-app.md
+++ b/src/pages/references/addonsdk/addonsdk-app.md
@@ -251,6 +251,57 @@ async function showInputDialog() {
 
 See the use case implementations for an example of the [custom modal dialog](../../guides/develop/use_cases.md#custom-dialog-example).
 
+### registerIframe()
+
+Allows an iframe hosted within an add-on to register its intent to communicate with the add-on SDK. While iframes can be used for embedding media without SDK interaction, `registerIframe()` is needed for those requiring SDK capabilities. It marks a transition to a more controlled approach, where add-ons must explicitly opt-in to this level of integration.
+
+#### Signature
+
+`registerIframe(element: HTMLIFrameElement): [UnregisterIframe]()`
+
+#### Parameters
+
+| Name              | Type                                 | Description   |
+| -------------     | -------------------------------------| -----------:  |
+| `element`           | `HTMLIFrameElement`                             | The iframe to register. |
+
+#### Return Value
+
+[`UnregisterIframe`](#unregisteriframe-type-definition)
+
+##### `UnregisterIframe` Type Definition
+
+Callback function that unregisters the previously registered iframe, ceasing its direct communication with the add-on SDK. Returns `void`.
+
+```ts
+type UnregisterIframe = () => void;
+```
+
+#### Example Usage
+
+```ts
+import addOnUISdk from "https://new.express.adobe.com/static/add-on-sdk/sdk.js";
+ 
+function RegisterIframe(elementId: string) {
+  const iframe = document.getElementById(elementId);
+  try {
+    unregisterIframe = addOnUISdk.app.registerIframe(iframe);
+  }
+  catch(error) {
+    console.log("Failed to register iframe with the SDK:", error);
+  }
+}
+ 
+addOnUISdk.ready.then(() => {
+  let unregisterIframe: UnregisterIframe = RegisterIframe("iframe1");
+  // ...
+  unregisterIframe();
+  unregisterIframe = RegisterIframe("iframe2");
+  // ...
+  unregisterIframe();
+});
+```
+
 ### enableDragToDocument()
 
 Allows for drag and document functionality to be enabled on an element such as an image, video or audio.

--- a/src/pages/references/addonsdk/addonsdk-constants.md
+++ b/src/pages/references/addonsdk/addonsdk-constants.md
@@ -89,6 +89,19 @@ A set of constants used throughout the add-on SDK. These constants are equal to 
     </td>
 </tr>
 <tr class="spectrum-Table-row">
+    <td class="spectrum-Table-cell"><p><pre>VideoResolution</pre></p></td>
+    <td class="spectrum-Table-cell"><p><pre>string</pre></p></td>
+    <td style="vertical-align: bottom;">
+        <p>Video resolution options for the mp4 renditions.</p>
+        <ul>
+          <li><strong>sd480p</strong></li>"480p"
+          <li><strong>hd720p</strong></li>"720p"
+          <li><strong>fhd1080p</strong></li>"1080p"
+          <li><strong>custom</strong></li>Custom resolution
+        </ul>
+    </td>
+</tr>
+<tr class="spectrum-Table-row">
     <td class="spectrum-Table-cell"><p><pre>DialogResultType</pre></p></td>
     <td class="spectrum-Table-cell"><p><pre>string</pre></p></td>
     <td style="vertical-align: bottom;">

--- a/src/pages/references/addonsdk/app-document.md
+++ b/src/pages/references/addonsdk/app-document.md
@@ -421,6 +421,16 @@ Represents margins for a PDF page box.
 | `left?` | [`Bleed`](#bleed) | Left margin |
 | `right?` | [`Bleed`](#bleed) | Right margin |
 
+#### `Mp4RenditionOptions`
+
+Extends the [`RenditionOptions`](#renditionoptions) object and adds the following additional options for `mp4` renditions:
+
+| Name                                      | Type                                |                                                                                                                                                                            Description |
+| ----------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| `format`                        | `string`                            | [`RenditionFormat.mp4`](./addonsdk-constants.md) constant value. |
+| `resolution?`                                | `string`                            |                                                                                                                    [`VideoResolution`](./addonsdk-constants.md) constant value. |
+| `customResolution?` | `number` |  Only required/used if the `resolution` is `VideoResolution.custom` |
+
 #### Return Value
 
 A `Promise` with an array of page `Rendition` objects (see [`PageRendition`](#pagerendition)). The array will contain one item if the `currentPage` range is requested, an array of specific pages when the `specificPages` range is requested, or all pages when the `entireDocument` range is specified. Each rendition returned will contain the `type`, `title`,[metadata for the page](#pagemetadata) and a `blob` of the rendition itself. **Note:** If you requested `PDF` for the format with a larger range than `currentPage`, a single file will be generated which includes the entire range. When the format is `JPG/PNG/MP4`, an array of files will be generated that represents each page.

--- a/src/pages/references/addonsdk/app-document.md
+++ b/src/pages/references/addonsdk/app-document.md
@@ -157,7 +157,7 @@ This object is passed as a parameter to the [`getPagesMetadata`](#getpagesmetada
 
 ### addImage()
 
-Adds an image (including a Ps/Ai file) to the current page.
+Adds an image (including gif/Ps/Ai files) to the current page.
 
 #### Signature
 
@@ -168,7 +168,7 @@ Adds an image (including a Ps/Ai file) to the current page.
 | Name          | Type         | Description                   |
 | ------------- | -------------| ----------------------------: |
 | `imageBlob`   | `Blob`       | The image to add to the page. |
-| `attributes`  | [`MediaAttributes`](#mediaattributes) | Attributes to pass when adding the image to the page (i.e., `title`, which is mandatory). |
+| `attributes?`  | [`MediaAttributes`](#mediaattributes) | Attributes that can be passed when adding Ps/Ai filse to the page (i.e., `title`). |
 
 #### `MediaAttributes`
 

--- a/src/pages/references/addonsdk/app-document.md
+++ b/src/pages/references/addonsdk/app-document.md
@@ -157,21 +157,28 @@ This object is passed as a parameter to the [`getPagesMetadata`](#getpagesmetada
 
 ### addImage()
 
-Adds an image to the current page.
+Adds an image (including a Ps/Ai file) to the current page.
 
 #### Signature
 
-`addImage(imageBlob: Blob): Promise<void>`
+`addImage(imageBlob: Blob, attributes?: MediaAttributes): Promise<void>`
 
 #### Parameters
 
 | Name          | Type         | Description                   |
 | ------------- | -------------| ----------------------------: |
 | `imageBlob`   | `Blob`       | The image to add to the page. |
+| `attributes`  | [`MediaAttributes`](#mediaattributes) | Attributes to pass when adding the image to the page (i.e., `title`, which is mandatory). |
+
+#### `MediaAttributes`
+
+| Name    | Type     |                               Description |
+| ------- | -------- | ----------------------------------------: |
+| `title` | `string` | Media title (mandatory for audio import). |
 
 #### Return Value
 
-A resolved promise if the image was successfully added to the canvas; otherwise will throw an error with the rejected promise.
+A resolved promise if the image was successfully added to the canvas; otherwise, it will throw an error with the rejected promise.
 
 #### Example Usage
 

--- a/src/pages/references/changelog.md
+++ b/src/pages/references/changelog.md
@@ -20,6 +20,14 @@ contributors:
 
 # Changelog
 
+## 2024-03-19
+
+- Support for Ps and Ai files to be added to the page via the [`addImage()`](../references/addonsdk/app-document.md#addimage) method. (Note: there were no changes to the drag-n-drop APIs).
+- Adds new `MediaAttributes` parameter to the [`addImage()`](../references/addonsdk/app-document.md#addimage) method for Ps/Ai file types to pass media attributes like `title`.
+- Adds new [`Mp4RenditionOptions`](../references/addonsdk/app-document.md#mp4renditionoptions) object to support `mp4` renditions.
+- Adds new [`VideoResolution`](../references/addonsdk/addonsdk-constants.md) constant to set video resolution options.
+- Adds [`registerIframe()`](../references/addonsdk/addonsdk-app.md#registeriframe) method and [`unregisterIframe`](../references/addonsdk/addonsdk-app.md#unregisteriframe-type-definition) type definition with example usage. **NOTE:** These APIs are currently experimental.
+
 ## 2024-03-08
 
 - [`getPagesMetadata()`](../references/addonsdk/app-document.md#getpagesmetadata), [`startPremiumUpgradeIfFreeUser`](../references/addonsdk/addonsdk-app.md#startpremiumupgradeiffreeuser) and [`isPremiumUser`](../references/addonsdk/app-currentUser.md#ispremiumuser) have been moved to stable and no longer require the `experimentalApis` flag to be set.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- `createRenditions` now provides option to specify the video resolution for the mp4 rendition format. 

- `registerIframe` is available as an experimental API.

- Ps and Ai file import is now supported.

- For Ps and Ai file import `addImage` adds a new optional parameter `attributes?: MediaAttributes`

- A new interface `Mp4RenditionOptions` and enum `VideoResolution` is added to support video resolution.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
