### PR TITLE
Document sandbox api changes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -232,6 +232,10 @@ module.exports = {
                     title: "UnknownNode",
                     path: "references/document-sandbox/document-apis/classes/UnknownNode.md",
                   },
+                  {
+                    title: "VisualNode",
+                    path: "references/document-sandbox/document-apis/classes/VisualNode.md",
+                  },
                 ],
               },
               {

--- a/src/pages/references/document-sandbox/document-apis/classes/ArtboardList.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/ArtboardList.md
@@ -85,7 +85,9 @@ ___
 ▸ **addArtboard**(): [`ArtboardNode`](ArtboardNode.md)
 
 Create a new artboard and add it to the end of the list. The artboard size is the same as others on this page. The
-artboard background is set to default fill color DEFAULT_ARTBOARD_FILL_COLOR.
+artboard background is set to default fill color DEFAULT_ARTBOARD_FILL_COLOR. The new artboard becomes the
+default target for newly inserted content (see insertionParent) and the timeline advances to show this artboard
+in the current viewport.
 
 #### Returns
 

--- a/src/pages/references/document-sandbox/document-apis/classes/ArtboardNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/ArtboardNode.md
@@ -8,7 +8,7 @@ When multiple artboards exist on a page, the artboards represent "scenes" in a l
 
 ## Hierarchy
 
-- [`BaseNode`](BaseNode.md)
+- [`VisualNode`](VisualNode.md)
 
   ↳ **`ArtboardNode`**
 
@@ -40,7 +40,53 @@ ContainerNode.allChildren
 
 #### Overrides
 
-BaseNode.allChildren
+VisualNode.allChildren
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Implementation of
+
+ContainerNode.boundsLocal
+
+#### Inherited from
+
+VisualNode.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Implementation of
+
+ContainerNode.centerPointLocal
+
+#### Inherited from
+
+VisualNode.centerPointLocal
 
 ___
 
@@ -64,13 +110,13 @@ ___
 
 • `get` **fill**(): `Readonly`<[`Fill`](../interfaces/Fill.md)\>
 
-The background fill of the artboard. Artboards must always have a fill.
-
 #### Returns
 
 `Readonly`<[`Fill`](../interfaces/Fill.md)\>
 
 • `set` **fill**(`fill`): `void`
+
+The background fill of the artboard. Artboards must always have a fill.
 
 #### Parameters
 
@@ -117,7 +163,7 @@ ContainerNode.id
 
 #### Inherited from
 
-BaseNode.id
+VisualNode.id
 
 ___
 
@@ -137,7 +183,29 @@ ContainerNode.parent
 
 #### Overrides
 
-BaseNode.parent
+VisualNode.parent
+
+___
+
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Implementation of
+
+ContainerNode.topLeftLocal
+
+#### Inherited from
+
+VisualNode.topLeftLocal
 
 ___
 
@@ -157,7 +225,32 @@ ContainerNode.type
 
 #### Inherited from
 
-BaseNode.type
+VisualNode.type
+
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Implementation of
+
+ContainerNode.visualRoot
+
+#### Inherited from
+
+VisualNode.visualRoot
 
 ___
 
@@ -176,6 +269,35 @@ The width of the artboard.
 [IRectangularNode](../interfaces/IRectangularNode.md).[width](../interfaces/IRectangularNode.md#width)
 
 ## Methods
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](ArtboardNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Implementation of
+
+[ContainerNode](../interfaces/ContainerNode.md).[localPointInNode](../interfaces/ContainerNode.md#localpointinnode)
+
+#### Inherited from
+
+[VisualNode](VisualNode.md).[localPointInNode](VisualNode.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -198,4 +320,4 @@ removal. No-op if node is already an orphan.
 
 #### Inherited from
 
-[BaseNode](BaseNode.md).[removeFromParent](BaseNode.md#removefromparent)
+[VisualNode](VisualNode.md).[removeFromParent](VisualNode.md#removefromparent)

--- a/src/pages/references/document-sandbox/document-apis/classes/BaseNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/BaseNode.md
@@ -13,15 +13,11 @@ properties.
 
   ↳ **`BaseNode`**
 
-  ↳↳ [`ArtboardNode`](ArtboardNode.md)
-
-  ↳↳ [`ContainerNode`](../interfaces/ContainerNode.md)
-
   ↳↳ [`ExpressRootNode`](ExpressRootNode.md)
 
-  ↳↳ [`Node`](Node.md)
-
   ↳↳ [`PageNode`](PageNode.md)
+
+  ↳↳ [`VisualNode`](VisualNode.md)
 
 ## Accessors
 

--- a/src/pages/references/document-sandbox/document-apis/classes/ComplexShapeNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/ComplexShapeNode.md
@@ -67,11 +67,67 @@ FillableNode.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](ComplexShapeNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+FillableNode.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+FillableNode.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+FillableNode.centerPointLocal
+
+___
+
 ### fill
 
 • `get` **fill**(): `undefined` \| `Readonly`<[`Fill`](../interfaces/Fill.md)\>
-
-The fill applied to the shape, if any.
 
 #### Returns
 
@@ -82,6 +138,8 @@ The fill applied to the shape, if any.
 FillableNode.fill
 
 • `set` **fill**(`fill`): `void`
+
+The fill applied to the shape, if any.
 
 #### Parameters
 
@@ -240,8 +298,6 @@ ___
 
 • `get` **stroke**(): `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
 
-The stroke applied to the shape, if any.
-
 #### Returns
 
 `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
@@ -251,6 +307,8 @@ The stroke applied to the shape, if any.
 FillableNode.stroke
 
 • `set` **stroke**(`stroke`): `void`
+
+The stroke applied to the shape, if any.
 
 #### Parameters
 
@@ -265,6 +323,24 @@ FillableNode.stroke
 #### Inherited from
 
 FillableNode.stroke
+
+___
+
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+FillableNode.topLeftLocal
 
 ___
 
@@ -286,7 +362,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -294,7 +370,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -306,9 +382,7 @@ FillableNode.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -334,7 +408,77 @@ The node's type.
 
 FillableNode.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+FillableNode.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](ComplexShapeNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](ComplexShapeNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[FillableNode](FillableNode.md).[boundsInNode](FillableNode.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](ComplexShapeNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[FillableNode](FillableNode.md).[localPointInNode](FillableNode.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -399,7 +543,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/Context.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/Context.md
@@ -12,6 +12,18 @@ Contains the user's current selection state, indicating the content they are foc
 
 ## Accessors
 
+### currentPage
+
+• `get` **currentPage**(): [`PageNode`](PageNode.md)
+
+#### Returns
+
+[`PageNode`](PageNode.md)
+
+The currently viewed page.
+
+___
+
 ### hasSelection
 
 • `get` **hasSelection**(): `boolean`

--- a/src/pages/references/document-sandbox/document-apis/classes/Editor.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/Editor.md
@@ -70,7 +70,7 @@ uncropped image initially, but cropping can be changed after it is created by mo
 container's mediaRectangle and maskShape children.
 
 Image creation involves some asynchronous steps. The image will be visible in this client almost instantly, but will
-render as a gray placeholder on other clients until it has been uploaded to storage and then downloaded by those clients.
+render as a gray placeholder on other clients until it has been uploaded to DCX and then downloaded by those clients.
 This local client will act as having unsaved changes until the upload has finished.
 
 #### Parameters
@@ -148,7 +148,7 @@ ___
 
 ### loadBitmapImage
 
-▸ **loadBitmapImage**(`bitmapData`): `Promise`<[`BitmapImage`](../interfaces/BitmapImage.md)\>
+▸ **loadBitmapImage**(`rendition`): `Promise`<[`BitmapImage`](../interfaces/BitmapImage.md)\>
 
 Creates a bitmap image resource in the document, which can be displayed in the scenegraph by passing it to [createImageContainer](Editor.md#createimagecontainer)
 to create a MediaContainerNode. The same BitmapImage can be used to create multiple MediaContainerNodes.
@@ -164,7 +164,7 @@ having unsaved changes until all the upload steps have finished.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `bitmapData` | `Blob` | Encoded image data in PNG or JPEG format. |
+| `rendition` | `Blob` | Encoded image data in PNG or JPEG format. |
 
 #### Returns
 

--- a/src/pages/references/document-sandbox/document-apis/classes/EllipseNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/EllipseNode.md
@@ -66,11 +66,67 @@ FillableNode.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](EllipseNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+FillableNode.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+FillableNode.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+FillableNode.centerPointLocal
+
+___
+
 ### fill
 
 • `get` **fill**(): `undefined` \| `Readonly`<[`Fill`](../interfaces/Fill.md)\>
-
-The fill applied to the shape, if any.
 
 #### Returns
 
@@ -81,6 +137,8 @@ The fill applied to the shape, if any.
 FillableNode.fill
 
 • `set` **fill**(`fill`): `void`
+
+The fill applied to the shape, if any.
 
 #### Parameters
 
@@ -293,8 +351,6 @@ ___
 
 • `get` **stroke**(): `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
 
-The stroke applied to the shape, if any.
-
 #### Returns
 
 `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
@@ -304,6 +360,8 @@ The stroke applied to the shape, if any.
 FillableNode.stroke
 
 • `set` **stroke**(`stroke`): `void`
+
+The stroke applied to the shape, if any.
 
 #### Parameters
 
@@ -318,6 +376,24 @@ FillableNode.stroke
 #### Inherited from
 
 FillableNode.stroke
+
+___
+
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+FillableNode.topLeftLocal
 
 ___
 
@@ -339,7 +415,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -347,7 +423,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -359,9 +435,7 @@ FillableNode.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -387,7 +461,77 @@ The node's type.
 
 FillableNode.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+FillableNode.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](EllipseNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](EllipseNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[FillableNode](FillableNode.md).[boundsInNode](FillableNode.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](EllipseNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[FillableNode](FillableNode.md).[localPointInNode](FillableNode.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -452,7 +596,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/FillableNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/FillableNode.md
@@ -78,11 +78,67 @@ StrokableNode.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](FillableNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+StrokableNode.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+StrokableNode.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+StrokableNode.centerPointLocal
+
+___
+
 ### fill
 
 • `get` **fill**(): `undefined` \| `Readonly`<[`Fill`](../interfaces/Fill.md)\>
-
-The fill applied to the shape, if any.
 
 #### Returns
 
@@ -93,6 +149,8 @@ The fill applied to the shape, if any.
 [IFillableNode](../interfaces/IFillableNode.md).[fill](../interfaces/IFillableNode.md#fill)
 
 • `set` **fill**(`fill`): `void`
+
+The fill applied to the shape, if any.
 
 #### Parameters
 
@@ -251,8 +309,6 @@ ___
 
 • `get` **stroke**(): `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
 
-The stroke applied to the shape, if any.
-
 #### Returns
 
 `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
@@ -262,6 +318,8 @@ The stroke applied to the shape, if any.
 StrokableNode.stroke
 
 • `set` **stroke**(`stroke`): `void`
+
+The stroke applied to the shape, if any.
 
 #### Parameters
 
@@ -276,6 +334,24 @@ StrokableNode.stroke
 #### Inherited from
 
 StrokableNode.stroke
+
+___
+
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+StrokableNode.topLeftLocal
 
 ___
 
@@ -297,7 +373,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -305,7 +381,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -317,9 +393,7 @@ StrokableNode.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -345,7 +419,77 @@ The node's type.
 
 StrokableNode.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+StrokableNode.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](FillableNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](FillableNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[StrokableNode](StrokableNode.md).[boundsInNode](StrokableNode.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](FillableNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[StrokableNode](StrokableNode.md).[localPointInNode](StrokableNode.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -410,7 +554,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/GridLayoutNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/GridLayoutNode.md
@@ -2,8 +2,8 @@
 
 # Class: GridLayoutNode
 
-A GridLayoutNode represents a grid layout in the scenegraph. The GridLayoutNode is used to
-create a layout grid that other content can be placed into.
+A GridLayoutNode represents a grid layout in the scenegraph. The GridLayoutNode is used to create
+a layout grid that other content can be placed into.
 
 ## Hierarchy
 
@@ -13,7 +13,7 @@ create a layout grid that other content can be placed into.
 
 ## Implements
 
-- [`IRectangularNode`](../interfaces/IRectangularNode.md)
+- `Readonly`<[`IRectangularNode`](../interfaces/IRectangularNode.md)\>
 
 ## Accessors
 
@@ -71,17 +71,75 @@ Node.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](GridLayoutNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.centerPointLocal
+
+___
+
 ### fill
 
 • `get` **fill**(): `Readonly`<[`Fill`](../interfaces/Fill.md)\>
-
-The background fill of the GridLayout.
 
 #### Returns
 
 `Readonly`<[`Fill`](../interfaces/Fill.md)\>
 
 • `set` **fill**(`fill`): `void`
+
+The background fill of the GridLayout.
 
 #### Parameters
 
@@ -107,7 +165,7 @@ The height of the node.
 
 #### Implementation of
 
-[IRectangularNode](../interfaces/IRectangularNode.md).[height](../interfaces/IRectangularNode.md#height)
+Readonly.height
 
 ___
 
@@ -248,6 +306,24 @@ Node.rotationInScreen
 
 ___
 
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.topLeftLocal
+
+___
+
 ### transformMatrix
 
 • `get` **transformMatrix**(): [`mat2d`](https://glmatrix.net/docs/module-mat2d.html)
@@ -266,7 +342,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -274,7 +350,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -286,9 +362,7 @@ Node.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -316,6 +390,27 @@ Node.type
 
 ___
 
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+Node.visualRoot
+
+___
+
 ### width
 
 • `get` **width**(): `number`
@@ -328,9 +423,58 @@ The width of the node.
 
 #### Implementation of
 
-[IRectangularNode](../interfaces/IRectangularNode.md).[width](../interfaces/IRectangularNode.md#width)
+Readonly.width
 
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](GridLayoutNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](GridLayoutNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[Node](Node.md).[boundsInNode](Node.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](GridLayoutNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[Node](Node.md).[localPointInNode](Node.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -395,7 +539,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/GroupNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/GroupNode.md
@@ -75,6 +75,68 @@ Node.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](GroupNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+Note: If this group has a maskShape, group's bounds are always identical to the maskShape's, regardless of the
+group's other content.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Implementation of
+
+ContainerNode.boundsLocal
+
+#### Overrides
+
+Node.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Implementation of
+
+ContainerNode.centerPointLocal
+
+#### Inherited from
+
+Node.centerPointLocal
+
+___
+
 ### children
 
 • `get` **children**(): [`ItemList`](ItemList.md)<[`Node`](Node.md)\>
@@ -271,6 +333,28 @@ Node.rotationInScreen
 
 ___
 
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Implementation of
+
+ContainerNode.topLeftLocal
+
+#### Inherited from
+
+Node.topLeftLocal
+
+___
+
 ### transformMatrix
 
 • `get` **transformMatrix**(): [`mat2d`](https://glmatrix.net/docs/module-mat2d.html)
@@ -289,7 +373,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -297,7 +381,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -309,9 +393,7 @@ Node.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -341,7 +423,85 @@ ContainerNode.type
 
 Node.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Implementation of
+
+ContainerNode.visualRoot
+
+#### Inherited from
+
+Node.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](GroupNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](GroupNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[Node](Node.md).[boundsInNode](Node.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](GroupNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Implementation of
+
+[ContainerNode](../interfaces/ContainerNode.md).[localPointInNode](../interfaces/ContainerNode.md#localpointinnode)
+
+#### Inherited from
+
+[Node](Node.md).[localPointInNode](Node.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -410,7 +570,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/ImageRectangleNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/ImageRectangleNode.md
@@ -72,6 +72,64 @@ Node.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](ImageRectangleNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.centerPointLocal
+
+___
+
 ### height
 
 • `get` **height**(): `number`
@@ -227,6 +285,24 @@ Node.rotationInScreen
 
 ___
 
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.topLeftLocal
+
+___
+
 ### transformMatrix
 
 • `get` **transformMatrix**(): [`mat2d`](https://glmatrix.net/docs/module-mat2d.html)
@@ -245,7 +321,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -253,7 +329,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -265,9 +341,7 @@ Node.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -295,6 +369,27 @@ Node.type
 
 ___
 
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+Node.visualRoot
+
+___
+
 ### width
 
 • `get` **width**(): `number`
@@ -312,6 +407,55 @@ will always match its aspect ratio.
 Readonly.width
 
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](ImageRectangleNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](ImageRectangleNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[Node](Node.md).[boundsInNode](Node.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](ImageRectangleNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[Node](Node.md).[localPointInNode](Node.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -376,7 +520,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/LineNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/LineNode.md
@@ -90,6 +90,64 @@ StrokableNode.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](LineNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+StrokableNode.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+StrokableNode.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+StrokableNode.centerPointLocal
+
+___
+
 ### endArrowHeadType
 
 • `get` **endArrowHeadType**(): [`ArrowHeadType`](../enums/ArrowHeadType.md)
@@ -335,8 +393,6 @@ ___
 
 • `get` **stroke**(): `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
 
-The stroke applied to the shape, if any.
-
 #### Returns
 
 `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
@@ -346,6 +402,8 @@ The stroke applied to the shape, if any.
 StrokableNode.stroke
 
 • `set` **stroke**(`stroke`): `void`
+
+The stroke applied to the shape, if any.
 
 #### Parameters
 
@@ -360,6 +418,24 @@ StrokableNode.stroke
 #### Inherited from
 
 StrokableNode.stroke
+
+___
+
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+StrokableNode.topLeftLocal
 
 ___
 
@@ -381,7 +457,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -389,7 +465,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -401,9 +477,7 @@ StrokableNode.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -429,7 +503,77 @@ The node's type.
 
 StrokableNode.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+StrokableNode.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](LineNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](LineNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[StrokableNode](StrokableNode.md).[boundsInNode](StrokableNode.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](LineNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[StrokableNode](StrokableNode.md).[localPointInNode](StrokableNode.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -521,7 +665,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/MediaContainerNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/MediaContainerNode.md
@@ -68,6 +68,64 @@ Node.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](MediaContainerNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.centerPointLocal
+
+___
+
 ### id
 
 • `get` **id**(): `string`
@@ -233,6 +291,24 @@ Node.rotationInScreen
 
 ___
 
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.topLeftLocal
+
+___
+
 ### transformMatrix
 
 • `get` **transformMatrix**(): [`mat2d`](https://glmatrix.net/docs/module-mat2d.html)
@@ -251,7 +327,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -259,7 +335,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -271,9 +347,7 @@ Node.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -299,7 +373,77 @@ The node's type.
 
 Node.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+Node.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](MediaContainerNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](MediaContainerNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[Node](Node.md).[boundsInNode](Node.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](MediaContainerNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[Node](Node.md).[localPointInNode](Node.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -364,7 +508,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/PageNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/PageNode.md
@@ -163,6 +163,23 @@ Readonly.width
 
 ## Methods
 
+### cloneInPlace
+
+▸ **cloneInPlace**(): [`PageNode`](PageNode.md)
+
+Clones this page, all artboards within it, and all content within those artboards. The cloned page is the same size
+as the original. Adds the new page immediately after this one in the pages list. The first artboard in the cloned
+page becomes the default target for newly inserted content ([insertionParent](Context.md#insertionparent)) and the viewport
+switches to display this artboard.
+
+#### Returns
+
+[`PageNode`](PageNode.md)
+
+the cloned page.
+
+___
+
 ### removeFromParent
 
 ▸ **removeFromParent**(): `void`

--- a/src/pages/references/document-sandbox/document-apis/classes/PathNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/PathNode.md
@@ -67,11 +67,67 @@ FillableNode.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](PathNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+FillableNode.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+FillableNode.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+FillableNode.centerPointLocal
+
+___
+
 ### fill
 
 • `get` **fill**(): `undefined` \| `Readonly`<[`Fill`](../interfaces/Fill.md)\>
-
-The fill applied to the shape, if any.
 
 #### Returns
 
@@ -82,6 +138,8 @@ The fill applied to the shape, if any.
 FillableNode.fill
 
 • `set` **fill**(`fill`): `void`
+
+The fill applied to the shape, if any.
 
 #### Parameters
 
@@ -110,13 +168,13 @@ has multiple disjoint parts. The default value is nonZero.
 
 [`FillRule`](../enums/FillRule.md)
 
-• `set` **fillRule**(`fillRule`): `void`
+• `set` **fillRule**(`rule`): `void`
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `fillRule` | [`FillRule`](../enums/FillRule.md) |
+| `rule` | [`FillRule`](../enums/FillRule.md) |
 
 #### Returns
 
@@ -279,8 +337,6 @@ ___
 
 • `get` **stroke**(): `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
 
-The stroke applied to the shape, if any.
-
 #### Returns
 
 `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
@@ -290,6 +346,8 @@ The stroke applied to the shape, if any.
 FillableNode.stroke
 
 • `set` **stroke**(`stroke`): `void`
+
+The stroke applied to the shape, if any.
 
 #### Parameters
 
@@ -304,6 +362,24 @@ FillableNode.stroke
 #### Inherited from
 
 FillableNode.stroke
+
+___
+
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+FillableNode.topLeftLocal
 
 ___
 
@@ -325,7 +401,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -333,7 +409,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -345,9 +421,7 @@ FillableNode.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -373,7 +447,77 @@ The node's type.
 
 FillableNode.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+FillableNode.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](PathNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](PathNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[FillableNode](FillableNode.md).[boundsInNode](FillableNode.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](PathNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[FillableNode](FillableNode.md).[localPointInNode](FillableNode.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -438,7 +582,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/RectangleNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/RectangleNode.md
@@ -128,11 +128,67 @@ even if the radius value set here is higher.
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](RectangleNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+FillableNode.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+FillableNode.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+FillableNode.centerPointLocal
+
+___
+
 ### fill
 
 • `get` **fill**(): `undefined` \| `Readonly`<[`Fill`](../interfaces/Fill.md)\>
-
-The fill applied to the shape, if any.
 
 #### Returns
 
@@ -143,6 +199,8 @@ The fill applied to the shape, if any.
 FillableNode.fill
 
 • `set` **fill**(`fill`): `void`
+
+The fill applied to the shape, if any.
 
 #### Parameters
 
@@ -334,8 +392,6 @@ ___
 
 • `get` **stroke**(): `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
 
-The stroke applied to the shape, if any.
-
 #### Returns
 
 `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
@@ -345,6 +401,8 @@ The stroke applied to the shape, if any.
 FillableNode.stroke
 
 • `set` **stroke**(`stroke`): `void`
+
+The stroke applied to the shape, if any.
 
 #### Parameters
 
@@ -359,6 +417,24 @@ FillableNode.stroke
 #### Inherited from
 
 FillableNode.stroke
+
+___
+
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+FillableNode.topLeftLocal
 
 ___
 
@@ -438,7 +514,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -446,7 +522,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -458,9 +534,7 @@ FillableNode.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -485,6 +559,27 @@ The node's type.
 #### Inherited from
 
 FillableNode.type
+
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+FillableNode.visualRoot
 
 ___
 
@@ -521,6 +616,30 @@ Must be at least MIN_DIMENSION.
 
 ## Methods
 
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](RectangleNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](RectangleNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[FillableNode](FillableNode.md).[boundsInNode](FillableNode.md#boundsinnode)
+
+___
+
 ### getUniformCornerRadius
 
 ▸ **getUniformCornerRadius**(): `undefined` \| `number`
@@ -531,6 +650,31 @@ If the corner radii differ, returns undefined.
 #### Returns
 
 `undefined` \| `number`
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](RectangleNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[FillableNode](FillableNode.md).[localPointInNode](FillableNode.md#localpointinnode)
 
 ___
 
@@ -597,7 +741,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/SolidColorShapeNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/SolidColorShapeNode.md
@@ -67,6 +67,64 @@ Node.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](SolidColorShapeNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.centerPointLocal
+
+___
+
 ### color
 
 • `get` **color**(): `undefined` \| `Readonly`<[`Color`](../interfaces/Color.md)\>
@@ -228,6 +286,24 @@ Node.rotationInScreen
 
 ___
 
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.topLeftLocal
+
+___
+
 ### transformMatrix
 
 • `get` **transformMatrix**(): [`mat2d`](https://glmatrix.net/docs/module-mat2d.html)
@@ -246,7 +322,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -254,7 +330,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -266,9 +342,7 @@ Node.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -294,7 +368,77 @@ The node's type.
 
 Node.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+Node.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](SolidColorShapeNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](SolidColorShapeNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[Node](Node.md).[boundsInNode](Node.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](SolidColorShapeNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[Node](Node.md).[localPointInNode](Node.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -359,7 +503,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/StrokableNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/StrokableNode.md
@@ -76,6 +76,64 @@ Node.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](StrokableNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.centerPointLocal
+
+___
+
 ### id
 
 • `get` **id**(): `string`
@@ -217,8 +275,6 @@ ___
 
 • `get` **stroke**(): `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
 
-The stroke applied to the shape, if any.
-
 #### Returns
 
 `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
@@ -228,6 +284,8 @@ The stroke applied to the shape, if any.
 [IStrokableNode](../interfaces/IStrokableNode.md).[stroke](../interfaces/IStrokableNode.md#stroke)
 
 • `set` **stroke**(`stroke`): `void`
+
+The stroke applied to the shape, if any.
 
 #### Parameters
 
@@ -242,6 +300,24 @@ The stroke applied to the shape, if any.
 #### Implementation of
 
 [IStrokableNode](../interfaces/IStrokableNode.md).[stroke](../interfaces/IStrokableNode.md#stroke)
+
+___
+
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.topLeftLocal
 
 ___
 
@@ -263,7 +339,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -271,7 +347,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -283,9 +359,7 @@ Node.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -311,7 +385,77 @@ The node's type.
 
 Node.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+Node.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](StrokableNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](StrokableNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[Node](Node.md).[boundsInNode](Node.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](StrokableNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[Node](Node.md).[localPointInNode](Node.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -376,7 +520,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/StrokeShapeNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/StrokeShapeNode.md
@@ -67,6 +67,64 @@ StrokableNode.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](StrokeShapeNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+StrokableNode.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+StrokableNode.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+StrokableNode.centerPointLocal
+
+___
+
 ### id
 
 • `get` **id**(): `string`
@@ -208,8 +266,6 @@ ___
 
 • `get` **stroke**(): `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
 
-The stroke applied to the shape, if any.
-
 #### Returns
 
 `undefined` \| `Readonly`<[`Stroke`](../interfaces/Stroke.md)\>
@@ -219,6 +275,8 @@ The stroke applied to the shape, if any.
 StrokableNode.stroke
 
 • `set` **stroke**(`stroke`): `void`
+
+The stroke applied to the shape, if any.
 
 #### Parameters
 
@@ -233,6 +291,24 @@ StrokableNode.stroke
 #### Inherited from
 
 StrokableNode.stroke
+
+___
+
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+StrokableNode.topLeftLocal
 
 ___
 
@@ -254,7 +330,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -262,7 +338,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -274,9 +350,7 @@ StrokableNode.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -302,7 +376,77 @@ The node's type.
 
 StrokableNode.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+StrokableNode.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](StrokeShapeNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](StrokeShapeNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[StrokableNode](StrokableNode.md).[boundsInNode](StrokableNode.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](StrokeShapeNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[StrokableNode](StrokableNode.md).[localPointInNode](StrokableNode.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -367,7 +511,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/TextNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/TextNode.md
@@ -66,6 +66,64 @@ Node.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](TextNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.centerPointLocal
+
+___
+
 ### id
 
 • `get` **id**(): `string`
@@ -251,6 +309,24 @@ The horizontal text alignment of the text node. Alignment is always the same acr
 
 ___
 
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.topLeftLocal
+
+___
+
 ### transformMatrix
 
 • `get` **transformMatrix**(): [`mat2d`](https://glmatrix.net/docs/module-mat2d.html)
@@ -269,7 +345,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -277,7 +353,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -289,9 +365,7 @@ Node.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -317,7 +391,77 @@ The node's type.
 
 Node.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+Node.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](TextNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](TextNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[Node](Node.md).[boundsInNode](Node.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](TextNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[Node](Node.md).[localPointInNode](Node.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -382,7 +526,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/UnknownNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/UnknownNode.md
@@ -66,6 +66,64 @@ Node.blendMode
 
 ___
 
+### boundsInParent
+
+• `get` **boundsInParent**(): `Readonly`<`Rect`\>
+
+An axis-aligned box in the parent’s coordinate space encompassing the node’s layout bounds (its
+[boundsLocal](UnknownNode.md#boundslocal), as transformed by its position and rotation relative to the parent). If the node has
+rotation, the top-left of its boundsLocal box (aligned to its own axes) is not necessarily located at the
+top-left of the boundsInParent box (since it's aligned to the parent's axes). This value is well-defined
+even for an orphan node with no parent.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsInParent
+
+___
+
+### boundsLocal
+
+• `get` **boundsLocal**(): `Readonly`<`Rect`\>
+
+The bounding box of the node, expressed in the node's local coordinate space (which may be shifted or rotated
+relative to its parent). Generally matches the selection outline seen in the UI, encompassing the vector path
+"spine" of the shape as well as its stroke, but excluding effects such as shadows.
+
+The top-left corner of the bounding box corresponds to the visual top-left corner of the node, but this value is
+*not* necessarily (0,0) – this is especially true for Text and Path nodes.
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+Node.boundsLocal
+
+___
+
+### centerPointLocal
+
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
+box.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.centerPointLocal
+
+___
+
 ### id
 
 • `get` **id**(): `string`
@@ -203,6 +261,24 @@ Node.rotationInScreen
 
 ___
 
+### topLeftLocal
+
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
+boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
+boundsInParent.
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+Node.topLeftLocal
+
+___
+
 ### transformMatrix
 
 • `get` **transformMatrix**(): [`mat2d`](https://glmatrix.net/docs/module-mat2d.html)
@@ -221,7 +297,7 @@ ___
 
 ### translation
 
-• `get` **translation**(): `Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+• `get` **translation**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 The translation of the node along its parent's axes. This is identical to the translation component of
 `transformMatrix`. It is often simpler to set a node's position using `setPositionInParent` than by
@@ -229,7 +305,7 @@ setting translation directly.
 
 #### Returns
 
-`Readonly`<{ `x`: `number` ; `y`: `number`  }\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 #### Inherited from
 
@@ -241,9 +317,7 @@ Node.translation
 
 | Name | Type |
 | :------ | :------ |
-| `value` | `Object` |
-| `value.x` | `number` |
-| `value.y` | `number` |
+| `value` | [`Point`](../interfaces/Point.md) |
 
 #### Returns
 
@@ -269,7 +343,77 @@ The node's type.
 
 Node.type
 
+___
+
+### visualRoot
+
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
+
+The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
+content, it will be the root of the deleted content (which might be this node itself).
+
+Nodes that are both in the same visualRoot subtree lie within the same "visual space" of the document's
+structure. Nodes that are in different visual roots have no spatial relation to one another; there is no
+meaningful comparison or conversion between the bounds or coordinate spaces of such nodes.
+
+#### Returns
+
+[`VisualNode`](VisualNode.md)
+
+#### Inherited from
+
+Node.visualRoot
+
 ## Methods
+
+### boundsInNode
+
+▸ **boundsInNode**(`targetNode`): `Readonly`<`Rect`\>
+
+Convert the node's [boundsLocal](UnknownNode.md#boundslocal) to an axis-aligned bounding box in the coordinate space of the target
+node. Both nodes must share the same [visualRoot](UnknownNode.md#visualroot), but can lie anywhere within that subtree
+relative to one another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<`Rect`\>
+
+#### Inherited from
+
+[Node](Node.md).[boundsInNode](Node.md#boundsinnode)
+
+___
+
+### localPointInNode
+
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
+
+Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
+Both nodes must share the same [visualRoot](UnknownNode.md#visualroot), but can lie anywhere within that subtree relative to one
+another (the target node need not be an ancestor of this node, nor vice versa).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
+
+#### Returns
+
+`Readonly`<[`Point`](../interfaces/Point.md)\>
+
+#### Inherited from
+
+[Node](Node.md).[localPointInNode](Node.md#localpointinnode)
+
+___
 
 ### removeFromParent
 
@@ -334,7 +478,7 @@ ___
 Set the node’s rotation angle relative to its parent to exactly the given value, keeping the given point in the
 node’s local coordinate space at a fixed location within the parent. Disregards any rotation the node may already
 have had. The angle set here may not be the absolute rotation angle seen on screen, if the parent or other
-ancestors have any rotation of their own.
+ancestors also have rotation of their own.
 
 **`Example`**
 

--- a/src/pages/references/document-sandbox/document-apis/classes/VisualNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/VisualNode.md
@@ -1,33 +1,34 @@
-[@express-document-sdk](../overview.md) / ContainerNode
+[@express-document-sdk](../overview.md) / VisualNode
 
-# Interface: ContainerNode
+# Class: VisualNode
 
-Interface for any node that contains an entirely generic collection of children. Some ContainerNode classes may host
-*additional* children in other specific "slots," such as background or mask layers; and non-ContainerNode classes may
-also hold children in specified "slots." Use [allChildren](../classes/Node.md#allchildren) for read access to children regardless of node type.
+A "node" represents an object in the scenegraph, the document's visual content tree. This class represents any node
+that can be visually perceived in the content. Most visual content is a subclass of the richer Node class which extends
+VisualNode with more properties, but the overall ArtboardNode container only supports the VisualNode APIs
+(and higher-level more abstract containers like PageNode extend only the minimal BaseNode class).
 
-Some ContainerNode classes may be full-fledged Node subclasses (such as Group), while others may be a subclass of the
-more minimal VisualNode (such as Artboard).
+Some VisualNodes might have a non-visual parent such as a PageNode.
 
 ## Hierarchy
 
-- [`VisualNode`](../classes/VisualNode.md)
+- [`BaseNode`](BaseNode.md)
 
-  ↳ **`ContainerNode`**
+  ↳ **`VisualNode`**
 
-## Implemented by
+  ↳↳ [`ArtboardNode`](ArtboardNode.md)
 
-- [`ArtboardNode`](../classes/ArtboardNode.md)
-- [`GroupNode`](../classes/GroupNode.md)
+  ↳↳ [`ContainerNode`](../interfaces/ContainerNode.md)
+
+  ↳↳ [`Node`](Node.md)
 
 ## Accessors
 
 ### allChildren
 
-• `get` **allChildren**(): `Readonly`<`Iterable`<[`BaseNode`](../classes/BaseNode.md)\>\>
+• `get` **allChildren**(): `Readonly`<`Iterable`<[`BaseNode`](BaseNode.md)\>\>
 
 Returns a read-only list of all children of the node. General-purpose content containers such as ArtboardNode or
-GroupNode also provide a mutable [children](ContainerNode.md#children) list. Other nodes with a more specific structure can
+GroupNode also provide a mutable [children](../interfaces/ContainerNode.md#children) list. Other nodes with a more specific structure can
 hold children in various discrete "slots"; this `allChildren` list includes *all* such children and reflects their
 overall display z-order.
 
@@ -36,11 +37,11 @@ to guarantee all their children are full-fledged Node instances.
 
 #### Returns
 
-`Readonly`<`Iterable`<[`BaseNode`](../classes/BaseNode.md)\>\>
+`Readonly`<`Iterable`<[`BaseNode`](BaseNode.md)\>\>
 
 #### Inherited from
 
-VisualNode.allChildren
+BaseNode.allChildren
 
 ___
 
@@ -59,38 +60,18 @@ The top-left corner of the bounding box corresponds to the visual top-left corne
 
 `Readonly`<`Rect`\>
 
-#### Inherited from
-
-VisualNode.boundsLocal
-
 ___
 
 ### centerPointLocal
 
-• `get` **centerPointLocal**(): `Readonly`<[`Point`](Point.md)\>
+• `get` **centerPointLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 Position of the node's centerpoint in its own local coordinate space, i.e. the center of the boundsLocal
 box.
 
 #### Returns
 
-`Readonly`<[`Point`](Point.md)\>
-
-#### Inherited from
-
-VisualNode.centerPointLocal
-
-___
-
-### children
-
-• `get` **children**(): [`ItemList`](../classes/ItemList.md)<[`Node`](../classes/Node.md)\>
-
-The node's children. Use the methods on this ItemList object to get, add, and remove children.
-
-#### Returns
-
-[`ItemList`](../classes/ItemList.md)<[`Node`](../classes/Node.md)\>
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 ___
 
@@ -107,13 +88,13 @@ moved to a different part of the document.
 
 #### Inherited from
 
-VisualNode.id
+BaseNode.id
 
 ___
 
 ### parent
 
-• `get` **parent**(): `undefined` \| [`BaseNode`](../classes/BaseNode.md)
+• `get` **parent**(): `undefined` \| [`BaseNode`](BaseNode.md)
 
 The node's parent. The parent chain will eventually reach ExpressRootNode for all nodes that are part of the document
 content.
@@ -124,17 +105,17 @@ that was part of the document content earlier. Deleted nodes can be reattached t
 
 #### Returns
 
-`undefined` \| [`BaseNode`](../classes/BaseNode.md)
+`undefined` \| [`BaseNode`](BaseNode.md)
 
 #### Inherited from
 
-VisualNode.parent
+BaseNode.parent
 
 ___
 
 ### topLeftLocal
 
-• `get` **topLeftLocal**(): `Readonly`<[`Point`](Point.md)\>
+• `get` **topLeftLocal**(): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 Position of the node's top-left corner in its own local coordinate space, equal to (boundsLocal.x,
 boundsLocal.y). If the node is rotated, this is not the same as the top-left corner of
@@ -142,11 +123,7 @@ boundsInParent.
 
 #### Returns
 
-`Readonly`<[`Point`](Point.md)\>
-
-#### Inherited from
-
-VisualNode.topLeftLocal
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 ___
 
@@ -162,13 +139,13 @@ The node's type.
 
 #### Inherited from
 
-VisualNode.type
+BaseNode.type
 
 ___
 
 ### visualRoot
 
-• `get` **visualRoot**(): [`VisualNode`](../classes/VisualNode.md)
+• `get` **visualRoot**(): [`VisualNode`](VisualNode.md)
 
 The highest ancestor that still has visual presence in the document. Typically an Artboard, but for orphaned
 content, it will be the root of the deleted content (which might be this node itself).
@@ -179,36 +156,28 @@ meaningful comparison or conversion between the bounds or coordinate spaces of s
 
 #### Returns
 
-[`VisualNode`](../classes/VisualNode.md)
-
-#### Inherited from
-
-VisualNode.visualRoot
+[`VisualNode`](VisualNode.md)
 
 ## Methods
 
 ### localPointInNode
 
-▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](Point.md)\>
+▸ **localPointInNode**(`localPoint`, `targetNode`): `Readonly`<[`Point`](../interfaces/Point.md)\>
 
 Convert a point given in the node’s local coordinate space to a point in the coordinate space of the target node.
-Both nodes must share the same [visualRoot](ContainerNode.md#visualroot), but can lie anywhere within that subtree relative to one
+Both nodes must share the same [visualRoot](VisualNode.md#visualroot), but can lie anywhere within that subtree relative to one
 another (the target node need not be an ancestor of this node, nor vice versa).
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `localPoint` | [`Point`](Point.md) |
-| `targetNode` | [`VisualNode`](../classes/VisualNode.md) |
+| `localPoint` | [`Point`](../interfaces/Point.md) |
+| `targetNode` | [`VisualNode`](VisualNode.md) |
 
 #### Returns
 
-`Readonly`<[`Point`](Point.md)\>
-
-#### Inherited from
-
-[VisualNode](../classes/VisualNode.md).[localPointInNode](../classes/VisualNode.md#localpointinnode)
+`Readonly`<[`Point`](../interfaces/Point.md)\>
 
 ___
 
@@ -229,4 +198,4 @@ removal. No-op if node is already an orphan.
 
 #### Inherited from
 
-[VisualNode](../classes/VisualNode.md).[removeFromParent](../classes/VisualNode.md#removefromparent)
+[BaseNode](BaseNode.md).[removeFromParent](BaseNode.md#removefromparent)

--- a/src/pages/references/document-sandbox/document-apis/enums/BlendMode.md
+++ b/src/pages/references/document-sandbox/document-apis/enums/BlendMode.md
@@ -6,7 +6,7 @@
 
 *Do not depend on the literal numeric values of these constants*, as they may change. Always reference the enum identifiers in your code.
 
-Determines how a scenende is composited on top of the content rendered below it.
+Determines how a scenenode is composited on top of the content rendered below it.
 
 If a node is inside a container whose blend mode anything other than [passThrough](BlendMode.md#passthrough), then the node's blend mode only
 interacts with other siblings within the same container. See documentation below for details.

--- a/src/pages/references/document-sandbox/document-apis/interfaces/ColorFill.md
+++ b/src/pages/references/document-sandbox/document-apis/interfaces/ColorFill.md
@@ -4,7 +4,7 @@
 
 Represents a solid-color fill.
 
-The most convenient way to create a stroke is via `Editor.makeColorFill()`.
+The most convenient way to create a fill is via `Editor.makeColorFill()`.
 
 ## Hierarchy
 

--- a/src/pages/references/document-sandbox/document-apis/overview.md
+++ b/src/pages/references/document-sandbox/document-apis/overview.md
@@ -46,6 +46,7 @@
 - [StrokeShapeNode](classes/StrokeShapeNode.md)
 - [TextNode](classes/TextNode.md)
 - [UnknownNode](classes/UnknownNode.md)
+- [VisualNode](classes/VisualNode.md)
 
 ## Interfaces
 


### PR DESCRIPTION
New document sandbox API changes:
PageNode.ts
- cloneInPlace()

Context.ts
- get currentPage()

GroupNode.ts
-  get boundsLocal()

Node.ts
- get boundsInParent()
- boundsInNode()

VisualNode.ts
- get visualRoot()
- get boundsLocal()
- get centerPointLocal()
- get topLeftLocal()
- localPointInNode()

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
