### PR TITLE
Stabilize per element metadata and selection change notification apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This section outlines the steps that should be taken to format the generated Doc
 
 10. Find and replace `\<` with `<` for all `.md` files.
 
+11. Find and replace "\n`Experimental`\n" with "" with a regex option turned on in VS Code for all `.md` files. This will remove the additional `Experimental` text from the generated docs.
+
 ## Adobe I/O Documentation Template Info
 
 This is a site template built with the [Adobe I/O Theme](https://github.com/adobe/aio-theme).

--- a/src/pages/references/document-sandbox/document-apis/classes/AddOnData.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/AddOnData.md
@@ -5,10 +5,6 @@
 AddOnData class provides APIs to read, write, remove private metadata to a Node.
 This metadata is accessible only to the add-on that has set it.
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 ## Accessors
 
 ### remainingQuota

--- a/src/pages/references/document-sandbox/document-apis/classes/ArtboardNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/ArtboardNode.md
@@ -25,10 +25,6 @@ Please note that creating and deleting an artboard in a single frame will crash 
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/BaseNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/BaseNode.md
@@ -19,10 +19,6 @@ properties.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/ComplexShapeNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/ComplexShapeNode.md
@@ -15,10 +15,6 @@ of multiple separate paths.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/EllipseNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/EllipseNode.md
@@ -16,10 +16,6 @@ To create new ellipse, see [Editor.createEllipse](Editor.md#createellipse).
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/ExpressRootNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/ExpressRootNode.md
@@ -18,10 +18,6 @@ The parent of ExpressRootNode is undefined, since it is the root of the document
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/FillableNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/FillableNode.md
@@ -25,10 +25,6 @@ Base class for a Node that can have its own fill and stroke.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/Fonts.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/Fonts.md
@@ -8,9 +8,7 @@ The Fonts class provides methods to work with fonts.
 
 ### fromPostscriptName()
 
-`Experimental`
-
-• **fromPostscriptName**(`postscriptName`): `Promise`\<`undefined` \| [`AvailableFont`](AvailableFont.md)\>
+• **fromPostscriptName**(`postscriptName`): `Promise`<`undefined` \| [`AvailableFont`](AvailableFont.md)\>
 
 <InlineAlert slots="text" variant="warning"/>
 

--- a/src/pages/references/document-sandbox/document-apis/classes/GridCellNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/GridCellNode.md
@@ -16,10 +16,6 @@ MediaRectangle child of the GridCellNode when those actions are applied.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/GridLayoutNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/GridLayoutNode.md
@@ -21,10 +21,6 @@ APIs to create a new grid layout are not yet available.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/GroupNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/GroupNode.md
@@ -21,10 +21,6 @@ To create new group, see [Editor.createGroup](Editor.md#creategroup).
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/ImageRectangleNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/ImageRectangleNode.md
@@ -23,10 +23,6 @@ container structure together.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/LineNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/LineNode.md
@@ -40,10 +40,6 @@ To create a new line, see [Editor.createLine](Editor.md#createline).
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/MediaContainerNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/MediaContainerNode.md
@@ -23,10 +23,6 @@ container with other content, such as videos, are not yet available.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/Node.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/Node.md
@@ -30,10 +30,6 @@ A Node’s parent is always a VisualContentNode but may not be another Node (e.g
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/PageNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/PageNode.md
@@ -22,10 +22,6 @@ To create new pages, see [PageList.addPage](PageList.md#addpage).
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/PathNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/PathNode.md
@@ -17,10 +17,6 @@ To create new paths, see [Editor.createPath](Editor.md#createpath).
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/RectangleNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/RectangleNode.md
@@ -20,10 +20,6 @@ To create a new rectangle, see [Editor.createRectangle](Editor.md#createrectangl
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/SolidColorShapeNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/SolidColorShapeNode.md
@@ -15,10 +15,6 @@ is composed of multiple separate paths.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/StrokableNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/StrokableNode.md
@@ -24,10 +24,6 @@ Base class for a Node that can have its own stroke.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/StrokeShapeNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/StrokeShapeNode.md
@@ -15,10 +15,6 @@ if it is composed of multiple separate paths.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/TextContentModel.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/TextContentModel.md
@@ -133,8 +133,6 @@ The complete text string, which may span multiple [TextNode](TextNode.md) "frame
 
 ### applyCharacterStyles()
 
-`Experimental`
-
 • **applyCharacterStyles**(`styles`, `range`?): `void`
 
 <InlineAlert slots="text" variant="warning"/>
@@ -170,8 +168,6 @@ entire paragraphs, it overlaps.
 ---
 
 ### applyParagraphStyles()
-
-`Experimental`
 
 • **applyParagraphStyles**(`styles`, `range`?): `void`
 

--- a/src/pages/references/document-sandbox/document-apis/classes/TextNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/TextNode.md
@@ -19,10 +19,6 @@ multi-frame text flows.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/classes/UnknownNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/UnknownNode.md
@@ -14,10 +14,6 @@ An UnknownNode is a node with limited support and therefore treated as a leaf no
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns
@@ -127,7 +123,7 @@ moved to a different part of the document.
 
 The node's lock/unlock state. Locked nodes are excluded from the selection (see [Context.selection](Context.md#selection)), and
 cannot be edited by the user in the UI unless they are unlocked first. Operations on locked nodes using the API
-are permitted, but developers should consider if modifying a locked node would align with user expectations
+are permitted. However, please consider if modifying a locked node would align with user expectations
 before using the API to make changes to locked nodes.
 
 • `set` **locked**(`locked`): `void`

--- a/src/pages/references/document-sandbox/document-apis/classes/VisualNode.md
+++ b/src/pages/references/document-sandbox/document-apis/classes/VisualNode.md
@@ -25,10 +25,6 @@ Some VisualNodes might have a non-visual parent such as a PageNode.
 
 • `get` **addOnData**(): [`AddOnData`](AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/enumerations/EditorEvent.md
+++ b/src/pages/references/document-sandbox/document-apis/enumerations/EditorEvent.md
@@ -2,10 +2,6 @@
 
 # Enumeration: EditorEvent
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 This enum represents the supported editor events.
 
 ## Enumeration Members

--- a/src/pages/references/document-sandbox/document-apis/enumerations/OrderedListNumbering.md
+++ b/src/pages/references/document-sandbox/document-apis/enumerations/OrderedListNumbering.md
@@ -14,37 +14,37 @@ Numbering types used to display ordered lists: 1, A, a, I, i 01, 001.
 
 • **doubleZeroPrefixNumeric**: `8`
 
-***
+---
 
 ### lowercaseAlpha
 
 • **lowercaseAlpha**: `3`
 
-***
+---
 
 ### lowercaseRomanNum
 
 • **lowercaseRomanNum**: `5`
 
-***
+---
 
 ### numeric
 
 • **numeric**: `1`
 
-***
+---
 
 ### singleZeroPrefixNumeric
 
 • **singleZeroPrefixNumeric**: `7`
 
-***
+---
 
 ### uppercaseAlpha
 
 • **uppercaseAlpha**: `2`
 
-***
+---
 
 ### uppercaseRomanNum
 

--- a/src/pages/references/document-sandbox/document-apis/enumerations/ParagraphListType.md
+++ b/src/pages/references/document-sandbox/document-apis/enumerations/ParagraphListType.md
@@ -14,7 +14,7 @@ Indicates list type: see [UnorderedListStyleInput](../interfaces/UnorderedListSt
 
 • **ordered**: `1`
 
-***
+---
 
 ### unordered
 

--- a/src/pages/references/document-sandbox/document-apis/interfaces/BaseParagraphStyles.md
+++ b/src/pages/references/document-sandbox/document-apis/interfaces/BaseParagraphStyles.md
@@ -12,7 +12,7 @@ setter-oriented [ParagraphStylesRangeInput](ParagraphStylesRangeInput.md).
 
 ## Extended by
 
-- [`ParagraphStyles`](ParagraphStyles.md)
+-   [`ParagraphStyles`](ParagraphStyles.md)
 
 ## Properties
 
@@ -23,7 +23,7 @@ setter-oriented [ParagraphStylesRangeInput](ParagraphStylesRangeInput.md).
 Spacing between lines, aka leading, expressed as a multiple of the font size's default spacing - ex. 1.5 = 150% of normal.
 It only affects the space *between* lines, not the space above the first line or below the last line.
 
-***
+---
 
 ### spaceAfter
 
@@ -32,7 +32,7 @@ It only affects the space *between* lines, not the space above the first line or
 Space after paragraph (in points). It does not affect the last paragraph. It is additive to the next paragraph's spaceBefore
 (adjacent spacing does not merge/collapse together).
 
-***
+---
 
 ### spaceBefore
 

--- a/src/pages/references/document-sandbox/document-apis/interfaces/ContainerNode.md
+++ b/src/pages/references/document-sandbox/document-apis/interfaces/ContainerNode.md
@@ -19,10 +19,6 @@ more minimal VisualNode (such as Artboard).
 
 • `get` **addOnData**(): [`AddOnData`](../classes/AddOnData.md)
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently _**experimental only**_ and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
-
 Get [AddOnData](../classes/AddOnData.md) reference for managing the private metadata on this node for this add-on.
 
 #### Returns

--- a/src/pages/references/document-sandbox/document-apis/interfaces/OrderedListStyleInput.md
+++ b/src/pages/references/document-sandbox/document-apis/interfaces/OrderedListStyleInput.md
@@ -10,7 +10,7 @@ Interface for specifying an ordered list style, such as a numbered list.
 
 ## Extends
 
-- `BaseParagraphListStyle`
+-   `BaseParagraphListStyle`
 
 ## Properties
 
@@ -24,7 +24,7 @@ A value from 0-8 that specifies indent/nesting level. Default is 0 if not provid
 
 `BaseParagraphListStyle.indentLevel`
 
-***
+---
 
 ### numbering?
 
@@ -35,7 +35,7 @@ The defaults for increasing indent are 1, a, i, I, and then they repeat.
 These markers and the prefix/postfix strings (if any) are displayed using the same font as the start of the
 paragraph's text content.
 
-***
+---
 
 ### postfix?
 
@@ -43,7 +43,7 @@ paragraph's text content.
 
 Additional string to display after each sequence number/letter, e.g. ")" or "."
 
-***
+---
 
 ### prefix?
 
@@ -51,7 +51,7 @@ Additional string to display after each sequence number/letter, e.g. ")" or "."
 
 Additional string to display before each sequence number/letter, e.g. "("
 
-***
+---
 
 ### type
 

--- a/src/pages/references/document-sandbox/document-apis/interfaces/ParagraphStyles.md
+++ b/src/pages/references/document-sandbox/document-apis/interfaces/ParagraphStyles.md
@@ -11,11 +11,11 @@ any range of characters, even a short span like one single word).
 
 ## Extends
 
-- [`BaseParagraphStyles`](BaseParagraphStyles.md)
+-   [`BaseParagraphStyles`](BaseParagraphStyles.md)
 
 ## Extended by
 
-- [`ParagraphStylesRange`](ParagraphStylesRange.md)
+-   [`ParagraphStylesRange`](ParagraphStylesRange.md)
 
 ## Properties
 
@@ -30,13 +30,13 @@ It only affects the space *between* lines, not the space above the first line or
 
 [`BaseParagraphStyles`](BaseParagraphStyles.md).[`lineSpacing`](BaseParagraphStyles.md#linespacing)
 
-***
+---
 
 ### list?
 
-• `optional` **list**: `Required`\<[`OrderedListStyleInput`](OrderedListStyleInput.md)\> \| `Required`\<[`UnorderedListStyleInput`](UnorderedListStyleInput.md)\>
+• `optional` **list**: `Required`<[`OrderedListStyleInput`](OrderedListStyleInput.md)\> \| `Required`<[`UnorderedListStyleInput`](UnorderedListStyleInput.md)\>
 
-***
+---
 
 ### spaceAfter
 
@@ -49,7 +49,7 @@ Space after paragraph (in points). It does not affect the last paragraph. It is 
 
 [`BaseParagraphStyles`](BaseParagraphStyles.md).[`spaceAfter`](BaseParagraphStyles.md#spaceafter)
 
-***
+---
 
 ### spaceBefore
 

--- a/src/pages/references/document-sandbox/document-apis/interfaces/ParagraphStylesInput.md
+++ b/src/pages/references/document-sandbox/document-apis/interfaces/ParagraphStylesInput.md
@@ -11,11 +11,11 @@ any fields not specified are left unchanged, preserving the text's existing styl
 
 ## Extends
 
-- `Partial`\<[`BaseParagraphStyles`](BaseParagraphStyles.md)\>
+-   `Partial`<[`BaseParagraphStyles`](BaseParagraphStyles.md)\>
 
 ## Extended by
 
-- [`ParagraphStylesRangeInput`](ParagraphStylesRangeInput.md)
+-   [`ParagraphStylesRangeInput`](ParagraphStylesRangeInput.md)
 
 ## Properties
 
@@ -30,13 +30,13 @@ It only affects the space *between* lines, not the space above the first line or
 
 `Partial.lineSpacing`
 
-***
+---
 
 ### list?
 
 • `optional` **list**: [`OrderedListStyleInput`](OrderedListStyleInput.md) \| [`UnorderedListStyleInput`](UnorderedListStyleInput.md)
 
-***
+---
 
 ### spaceAfter?
 
@@ -49,7 +49,7 @@ Space after paragraph (in points). It does not affect the last paragraph. It is 
 
 `Partial.spaceAfter`
 
-***
+---
 
 ### spaceBefore?
 

--- a/src/pages/references/document-sandbox/document-apis/interfaces/ParagraphStylesRange.md
+++ b/src/pages/references/document-sandbox/document-apis/interfaces/ParagraphStylesRange.md
@@ -10,7 +10,7 @@ A set of [ParagraphStyles](ParagraphStyles.md) and the text range they apply to.
 
 ## Extends
 
-- [`ParagraphStyles`](ParagraphStyles.md).[`StyleRange`](StyleRange.md)
+-   [`ParagraphStyles`](ParagraphStyles.md).[`StyleRange`](StyleRange.md)
 
 ## Properties
 
@@ -26,7 +26,7 @@ such as emojis are considered to have a length of 2.
 
 [`StyleRange`](StyleRange.md).[`length`](StyleRange.md#length)
 
-***
+---
 
 ### lineSpacing
 
@@ -39,17 +39,17 @@ It only affects the space *between* lines, not the space above the first line or
 
 [`ParagraphStyles`](ParagraphStyles.md).[`lineSpacing`](ParagraphStyles.md#linespacing)
 
-***
+---
 
 ### list?
 
-• `optional` **list**: `Required`\<[`OrderedListStyleInput`](OrderedListStyleInput.md)\> \| `Required`\<[`UnorderedListStyleInput`](UnorderedListStyleInput.md)\>
+• `optional` **list**: `Required`<[`OrderedListStyleInput`](OrderedListStyleInput.md)\> \| `Required`<[`UnorderedListStyleInput`](UnorderedListStyleInput.md)\>
 
 #### Inherited from
 
 [`ParagraphStyles`](ParagraphStyles.md).[`list`](ParagraphStyles.md#list)
 
-***
+---
 
 ### spaceAfter
 
@@ -62,7 +62,7 @@ Space after paragraph (in points). It does not affect the last paragraph. It is 
 
 [`ParagraphStyles`](ParagraphStyles.md).[`spaceAfter`](ParagraphStyles.md#spaceafter)
 
-***
+---
 
 ### spaceBefore
 

--- a/src/pages/references/document-sandbox/document-apis/interfaces/ParagraphStylesRangeInput.md
+++ b/src/pages/references/document-sandbox/document-apis/interfaces/ParagraphStylesRangeInput.md
@@ -14,7 +14,7 @@ those boundaries.
 
 ## Extends
 
-- [`ParagraphStylesInput`](ParagraphStylesInput.md).[`StyleRange`](StyleRange.md)
+-   [`ParagraphStylesInput`](ParagraphStylesInput.md).[`StyleRange`](StyleRange.md)
 
 ## Properties
 
@@ -30,7 +30,7 @@ such as emojis are considered to have a length of 2.
 
 [`StyleRange`](StyleRange.md).[`length`](StyleRange.md#length)
 
-***
+---
 
 ### lineSpacing?
 
@@ -43,7 +43,7 @@ It only affects the space *between* lines, not the space above the first line or
 
 [`ParagraphStylesInput`](ParagraphStylesInput.md).[`lineSpacing`](ParagraphStylesInput.md#linespacing)
 
-***
+---
 
 ### list?
 
@@ -53,7 +53,7 @@ It only affects the space *between* lines, not the space above the first line or
 
 [`ParagraphStylesInput`](ParagraphStylesInput.md).[`list`](ParagraphStylesInput.md#list)
 
-***
+---
 
 ### spaceAfter?
 
@@ -66,7 +66,7 @@ Space after paragraph (in points). It does not affect the last paragraph. It is 
 
 [`ParagraphStylesInput`](ParagraphStylesInput.md).[`spaceAfter`](ParagraphStylesInput.md#spaceafter)
 
-***
+---
 
 ### spaceBefore?
 

--- a/src/pages/references/document-sandbox/document-apis/interfaces/UnorderedListStyleInput.md
+++ b/src/pages/references/document-sandbox/document-apis/interfaces/UnorderedListStyleInput.md
@@ -10,7 +10,7 @@ Interface for specifying an unordered list style, such as a bullet list.
 
 ## Extends
 
-- `BaseParagraphListStyle`
+-   `BaseParagraphListStyle`
 
 ## Properties
 
@@ -24,7 +24,7 @@ A value from 0-8 that specifies indent/nesting level. Default is 0 if not provid
 
 `BaseParagraphListStyle.indentLevel`
 
-***
+---
 
 ### marker?
 
@@ -37,7 +37,7 @@ paragraph's text content. A default marker is used instead if the default font d
 
 Text or Unicode glyphs are accepted to represent the list marker.
 
-***
+---
 
 ### type
 

--- a/src/pages/references/document-sandbox/document-apis/type-aliases/EditorEventHandler.md
+++ b/src/pages/references/document-sandbox/document-apis/type-aliases/EditorEventHandler.md
@@ -2,13 +2,7 @@
 
 # Type alias: EditorEventHandler()
 
-`Experimental`
-
 • **EditorEventHandler**: () => `void`
-
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
 
 This type represents function signature for the editor event handler callback.
 

--- a/src/pages/references/document-sandbox/document-apis/type-aliases/EventHandlerId.md
+++ b/src/pages/references/document-sandbox/document-apis/type-aliases/EventHandlerId.md
@@ -2,12 +2,6 @@
 
 # Type alias: EventHandlerId
 
-`Experimental`
-
 • **EventHandlerId**: `string`
-
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently ***experimental only*** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../manifest/index.md#requirements) section of the `manifest.json`.
 
 This type represents unique id of each event handler callback that is registered.

--- a/src/pages/references/document-sandbox/document-apis/type-aliases/Font.md
+++ b/src/pages/references/document-sandbox/document-apis/type-aliases/Font.md
@@ -2,8 +2,6 @@
 
 # Type alias: Font
 
-`Experimental`
-
 • **Font**: [`AvailableFont`](../classes/AvailableFont.md) \| [`UnavailableFont`](../classes/UnavailableFont.md)
 
 <InlineAlert slots="text" variant="warning"/>

--- a/src/pages/references/document-sandbox/document-apis/type-aliases/OrderedListStyle.md
+++ b/src/pages/references/document-sandbox/document-apis/type-aliases/OrderedListStyle.md
@@ -2,9 +2,7 @@
 
 # Type alias: OrderedListStyle
 
-`Experimental`
-
-• **OrderedListStyle**: `Required`\<[`OrderedListStyleInput`](../interfaces/OrderedListStyleInput.md)\>
+• **OrderedListStyle**: `Required`<[`OrderedListStyleInput`](../interfaces/OrderedListStyleInput.md)\>
 
 <InlineAlert slots="text" variant="warning"/>
 

--- a/src/pages/references/document-sandbox/document-apis/type-aliases/UnorderedListStyle.md
+++ b/src/pages/references/document-sandbox/document-apis/type-aliases/UnorderedListStyle.md
@@ -2,9 +2,7 @@
 
 # Type alias: UnorderedListStyle
 
-`Experimental`
-
-• **UnorderedListStyle**: `Required`\<[`UnorderedListStyleInput`](../interfaces/UnorderedListStyleInput.md)\>
+• **UnorderedListStyle**: `Required`<[`UnorderedListStyleInput`](../interfaces/UnorderedListStyleInput.md)\>
 
 <InlineAlert slots="text" variant="warning"/>
 


### PR DESCRIPTION
Stabilize per element metadata 
- `node.addOnData`

and selection change notification apis
- `editor.context.on()`
- `editor.context.off()`
-  `EditorEvent`, `EditorEventHandler`, `EventHandlerId`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
