### PR TITLE
Removed experimental warnings in use text guide for stable APIs

### DIFF
--- a/src/pages/guides/getting_started/changelog.md
+++ b/src/pages/guides/getting_started/changelog.md
@@ -22,6 +22,46 @@ contributors:
 
 # Changelog
 
+## 2025-10-08
+
+### Added
+
+- **Experimental** [`rescaleProportionalToHeight()`](../../references/document-sandbox/document-apis/classes/Node.md#rescaleproportionaltoheight) method - Proportional height scaling for all node types
+- **Experimental** [`rescaleProportionalToWidth()`](../../references/document-sandbox/document-apis/classes/Node.md#rescaleproportionaltowidth) method - Proportional width scaling for all node types  
+- **Experimental** [`resizeToCover()`](../../references/document-sandbox/document-apis/classes/Node.md#resizetocover) method - Resize nodes to cover specified dimensions
+- **Experimental** [`resizeToFitWithin()`](../../references/document-sandbox/document-apis/classes/Node.md#resizetofitwithin) method - Resize nodes to fit within specified dimensions
+- **Experimental** [`appendText()`](../../references/document-sandbox/document-apis/classes/TextContentModel.md#appendtext) method - Append text to existing content
+- **Experimental** [`deleteText()`](../../references/document-sandbox/document-apis/classes/TextContentModel.md#deletetext) method - Delete text ranges from content
+- **Experimental** [`insertText()`](../../references/document-sandbox/document-apis/classes/TextContentModel.md#inserttext) method - Insert text at specific positions
+- **Experimental** [`replaceText()`](../../references/document-sandbox/document-apis/classes/TextContentModel.md#replacetext) method - Replace text ranges with new content
+- **Experimental** [`hasUnavailableFonts()`](../../references/document-sandbox/document-apis/classes/TextContentModel.md#hasunavailablefonts) method - Check for unavailable fonts in text content
+- **Experimental** [`id`](../../references/document-sandbox/document-apis/classes/TextContentModel.md#id) property - Unique identifier for text content models
+- **Experimental** [`TextStyleSource`](../../references/document-sandbox/document-apis/namespaces/Constants/enumerations/TextStyleSource.md) enumeration - Options for text style source matching
+
+### Updated
+
+- [`cloneInPlace()`](../../references/document-sandbox/document-apis/classes/Node.md#cloneinplace) method **promoted from experimental to stable** - Available on all node types for creating copies with subtrees
+- [`paragraphStyleRanges`](../../references/document-sandbox/document-apis/classes/TextContentModel.md#paragraphstyleranges) property **promoted from experimental to stable** - Get/set paragraph-level styles with ranges
+- [`applyParagraphStyles()`](../../references/document-sandbox/document-apis/classes/TextContentModel.md#applyparagraphstyles) method **promoted from experimental to stable** - Apply styles to specific paragraph ranges
+- [`layout`](../../references/document-sandbox/document-apis/classes/StandaloneTextNode.md#layout) property **promoted from experimental to stable** - Control text layout modes for standalone text
+- [`layout`](../../references/document-sandbox/document-apis/classes/ThreadedTextNode.md#layout) property **promoted from experimental to stable** - Control text layout modes for threaded text
+- [`AreaTextLayout`](../../references/document-sandbox/document-apis/interfaces/AreaTextLayout.md) interface **promoted from experimental to stable** - Fixed width and height text layout configuration
+- [`AutoHeightTextLayout`](../../references/document-sandbox/document-apis/interfaces/AutoHeightTextLayout.md) interface **promoted from experimental to stable** - Auto-height text layout configuration
+- [`AutoWidthTextLayout`](../../references/document-sandbox/document-apis/interfaces/AutoWidthTextLayout.md) interface **promoted from experimental to stable** - Auto-width text layout configuration
+- [`UnsupportedTextLayout`](../../references/document-sandbox/document-apis/interfaces/UnsupportedTextLayout.md) interface **promoted from experimental to stable** - Representation of unsupported text layouts
+- [`ParagraphStyles`](../../references/document-sandbox/document-apis/interfaces/ParagraphStyles.md) interface **promoted from experimental to stable** - Complete paragraph style definitions
+- [`ParagraphStylesInput`](../../references/document-sandbox/document-apis/interfaces/ParagraphStylesInput.md) interface **promoted from experimental to stable** - Input interface for paragraph styles
+- [`ParagraphStylesRange`](../../references/document-sandbox/document-apis/interfaces/ParagraphStylesRange.md) interface **promoted from experimental to stable** - Paragraph styles with text ranges
+- [`ParagraphStylesRangeInput`](../../references/document-sandbox/document-apis/interfaces/ParagraphStylesRangeInput.md) interface **promoted from experimental to stable** - Input interface for paragraph style ranges
+- [`BaseParagraphStyles`](../../references/document-sandbox/document-apis/interfaces/BaseParagraphStyles.md) interface **promoted from experimental to stable** - Base paragraph style properties
+- [`OrderedListStyleInput`](../../references/document-sandbox/document-apis/interfaces/OrderedListStyleInput.md) interface **promoted from experimental to stable** - Configuration for ordered lists
+- [`UnorderedListStyleInput`](../../references/document-sandbox/document-apis/interfaces/UnorderedListStyleInput.md) interface **promoted from experimental to stable** - Configuration for unordered lists
+- [`OrderedListStyle`](../../references/document-sandbox/document-apis/type-aliases/OrderedListStyle.md) type **promoted from experimental to stable** - Type definition for ordered list styles
+- [`UnorderedListStyle`](../../references/document-sandbox/document-apis/type-aliases/UnorderedListStyle.md) type **promoted from experimental to stable** - Type definition for unordered list styles
+- [`OrderedListNumbering`](../../references/document-sandbox/document-apis/namespaces/Constants/enumerations/OrderedListNumbering.md) enumeration **promoted from experimental to stable** - Numbering types for ordered lists
+- [`ParagraphListType`](../../references/document-sandbox/document-apis/namespaces/Constants/enumerations/ParagraphListType.md) enumeration **promoted from experimental to stable** - List type enumeration with `none` value added
+- Removed experimental warnings from documentation guides for all APIs promoted to stable, including the [Use Text](../learn/how_to/use_text.md) guide
+
 ## 2025-10-02
 
 ### Added

--- a/src/pages/guides/learn/how_to/use_text.md
+++ b/src/pages/guides/learn/how_to/use_text.md
@@ -54,7 +54,7 @@ faq:
       answer: "Because `fromPostscriptName()` is async; wrap the style edit in `editor.queueAsyncEdit()`."
 
     - question: "How do I apply paragraph-level formatting?"
-      answer: 'Use `fullContent.applyParagraphStyles(styles, range)` (requires `"experimentalApis": true` in the `manifest.json`).'
+      answer: 'Use `fullContent.applyParagraphStyles(styles, range)`.'
 
     - question: "Where can I inspect paragraph formats?"
       answer: "Read or modify `fullContent.paragraphStyleRanges`."
@@ -786,10 +786,6 @@ try {
 
 Paragraph styles can be applied to a TextNode using the [`fullContent.applyParagraphStyles()`](../../../references/document-sandbox/document-apis/classes/TextContentModel.md#applyparagraphstyles) method. This method applies one or more style properties to entire paragraphs within the specified range, while leaving any style properties that are not provided unchanged. In contrast to directly setting the [`paragraphStyleRanges`](../../../references/document-sandbox/document-apis/classes/TextContentModel.md#paragraphstyleranges) property—which resets any unspecified properties to their defaults—using `applyParagraphStyles()` lets you update only the desired aspects of the style.
 
-<InlineAlert slots="text" variant="warning"/>
-
-**IMPORTANT:** This is currently **_experimental only_** and should not be used in any add-ons you will be distributing until it has been declared stable. To use it, you will first need to set the `experimentalApis` flag to `true` in the [`requirements`](../../../references/manifest/index.md#requirements) section of the `manifest.json`.
-
 The available properties are defined by the [`ParagraphStylesInput`](../../../references/document-sandbox/document-apis/interfaces/ParagraphStylesInput.md) interface and include:
 
 - **lineSpacing**: Specifies the spacing between lines (leading), expressed as a multiple of the font’s default spacing (e.g. 1.5 means 150% of normal).
@@ -958,7 +954,7 @@ for (const textNode of selectedTextNode.fullContent.allTextNodes) {
 
 #### Q: How do I apply paragraph-level formatting?
 
-**A:** Use `fullContent.applyParagraphStyles(styles, range)` (requires `"experimentalApis": true` in the `manifest.json`).
+**A:** Use `fullContent.applyParagraphStyles(styles, range)`.
 
 #### Q: Where can I inspect paragraph formats?
 

--- a/src/pages/references/changelog.md
+++ b/src/pages/references/changelog.md
@@ -63,6 +63,7 @@ contributors:
 - [`UnorderedListStyle`](../references/document-sandbox/document-apis/type-aliases/UnorderedListStyle.md) type **promoted from experimental to stable** - Type definition for unordered list styles
 - [`OrderedListNumbering`](../references/document-sandbox/document-apis/namespaces/Constants/enumerations/OrderedListNumbering.md) enumeration **promoted from experimental to stable** - Numbering types for ordered lists
 - [`ParagraphListType`](../references/document-sandbox/document-apis/namespaces/Constants/enumerations/ParagraphListType.md) enumeration **promoted from experimental to stable** - List type enumeration with `none` value added
+- Removed experimental warnings from documentation guides for all APIs promoted to stable, including the [Use Text](../guides/learn/how_to/use_text.md) guide
 
 ## 2025-10-02
 


### PR DESCRIPTION
## Description

Removed experimental API warnings in the Use Text guide for the newly stable APIs from 10-08-2025, and updated both changelogs to match with a new message about the warning removal.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
