### PR TITLE
Change 'mcpServers' to 'servers' in mcp.json

### DIFF
--- a/src/pages/guides/getting_started/local_development/mcp_server.md
+++ b/src/pages/guides/getting_started/local_development/mcp_server.md
@@ -126,7 +126,7 @@ Add this to your workspace in `~/.vscode/mcp.json`:
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "adobe-express-add-on": {
       "command": "npx",
       "args": [


### PR DESCRIPTION
Updated configuration key from 'mcpServers' to 'servers' in mcp.json.

Small change to VSCode users to copy the code.

## Description

VSCode json for adding an MCP server uses "servers" property, not "mcpServers". 
Reference: [Microsoft Doc](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)

## Related Issue

[https://github.com/AdobeDocs/express-add-ons-docs/issues/177](https://github.com/AdobeDocs/express-add-ons-docs/issues/177)

## Motivation and Context

Code copying and paste.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
